### PR TITLE
Infra 2089 fix molecule errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV PY_COLORS=1 \
     ANSIBLE_FORCE_COLOR=1
 
 RUN apt-get update \
-    && apt-get install -y build-essential openssh-client git docker.io \
+    && apt-get install -y build-essential openssh-client git docker.io rsync \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,10 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip
-RUN pip install --upgrade --user setuptools
-RUN pip install Jinja2
+RUN pip install --upgrade pip setuptools
 
 COPY requirements.txt /tmp/
 
 RUN pip install -r /tmp/requirements.txt
 
-CMD cd /tmp/$(basename "$PWD"); molecule ${command:-test}
+CMD cd ${GITHUB_REPOSITORY:-/tmp/$(basename "$PWD")}; molecule ${command:-test}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,12 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN python -m pip install --upgrade pip
+RUN pip install --upgrade --user setuptools
+RUN pip install Jinja2
+
 COPY requirements.txt /tmp/
 
 RUN pip install -r /tmp/requirements.txt
 
-CMD cd ${GITHUB_REPOSITORY:-/tmp/$(basename "$PWD")}; molecule ${command:-test}
+CMD cd /tmp/$(basename "$PWD"); molecule ${command:-test}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.9.20
+ansible==2.10.0
 ansible-lint>=5.0.8
 docker>=4.3.1
 pytest-testinfra>=6.3.0
@@ -6,5 +6,6 @@ yamllint==1.26.1
 decorator>=4.4.1
 openstacksdk>=0.56.0
 molecule==3.3.1
-molecule-docker>=0.2.4
+molecule-docker<=1.0.0
 molecule-openstack>=0.3.0
+ansible-lint<6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-ansible==2.10.0
-ansible-lint>=5.0.8
+ansible==6.2.0
+ansible-lint>=5.1.2,<6.0.0
 docker>=4.3.1
 pytest-testinfra>=6.3.0
 yamllint==1.26.1
 decorator>=4.4.1
 openstacksdk>=0.56.0
-molecule==3.3.1
-molecule-docker<=1.0.0
+molecule==4.0.1
+molecule-docker>=0.2.4
 molecule-openstack>=0.3.0
-ansible-lint<6.0.0
+molecule-vagrant>=1.0.0


### PR DESCRIPTION
Обновления пакетов необходимо для резолва ошибок

- https://github.com/ansible-community/molecule/issues/3498
- https://github.com/ansible/ansible/issues/77413

`TASK [Destroy molecule instance(s)] *********************************************************************************************************************************************************************************
[WARNING]: Skipping plugin (/usr/local/lib/python3.8/site-packages/ansible/plugins/filter/core.py) as it seems to be invalid: cannot import name 'environmentfilter' from 'jinja2.filters'
(/usr/local/lib/python3.8/site-packages/jinja2/filters.py)
[WARNING]: Skipping plugin (/usr/local/lib/python3.8/site-packages/ansible/plugins/filter/mathstuff.py) as it seems to be invalid: cannot import name 'environmentfilter' from 'jinja2.filters'
(/usr/local/lib/python3.8/site-packages/jinja2/filters.py)
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while templating '{{ lookup('file', molecule_file) | from_yaml }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: template error while templating string: No filter named 'from_yaml'.. String: {{ lookup('file', molecule_file) | from_yaml }}"}`