### PR TITLE
INFRA-2146: Update Molecule to have cgroups_mode option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest-testinfra>=6.3.0
 yamllint==1.26.1
 decorator>=4.4.1
 openstacksdk>=0.56.0
-molecule==4.0.1
+molecule==4.0.3
 molecule-docker>=0.2.4
 molecule-openstack>=0.3.0
 molecule-vagrant>=1.0.0


### PR DESCRIPTION
Обновил molecule 4.0.1 --> 4.0.3 для того, чтобы появилась возможность использовать параметр `cgroups_mode` для исправления ошибки работы molecule с `docker` и `systemd` более новой версии