### PR TITLE
Molecule 4.0.1 & python3-apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,7 @@ COPY requirements.txt /tmp/
 
 RUN pip install -r /tmp/requirements.txt
 
+RUN apt update \
+    && apt install -y python3-apt
+
 CMD cd ${GITHUB_REPOSITORY:-/tmp/$(basename "$PWD")}; molecule ${command:-test}

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,6 @@ inputs:
 
 runs:
   using: docker
-  image: docker://uchiru/molecule-action:3.3.1
+  image: docker://uchiru/molecule-action:4.0.1
   env:
     command: ${{ inputs.command }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest-testinfra>=6.3.0
 yamllint==1.26.1
 decorator>=4.4.1
 openstacksdk>=0.56.0
-molecule==4.0.3
+molecule==4.0.1
 molecule-docker>=0.2.4
 molecule-openstack>=0.3.0
 molecule-vagrant>=1.0.0


### PR DESCRIPTION
Версия molecule обновлена до 4.0.1
Установлен пакет `python3-apt`, нужен, чтобы можно было менять значения интерпретатора python в ansible