### PR TITLE
INFRA-2261: move build push to docker hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
     uses: uchiru/platform-gha-workflows/.github/workflows/build-push.yml@master
     with:
       tag: ${{ needs.bump.outputs.tag }}
-      registry: sysregistry.runit.cc
+      registry: docker.io
       build-args: version=${{ needs.bump.outputs.tag }}
     secrets:
-      username: ${{ secrets.REGISTRY_USERNAME }}
-      password: ${{ secrets.REGISTRY_PASSWORD }}
+      username: ${{ secrets.DOCKERHUB_LOGIN }}
+      password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,6 @@ inputs:
 
 runs:
   using: docker
-  image: docker://uchiru/molecule-action:v0.10
+  image: docker://uchiru/molecule-action:v1.6
   env:
     command: ${{ inputs.command }}


### PR DESCRIPTION
Перенес build push в docker.io т к bin/release не верно отрабатывает теги