### PR TITLE
INFRA-2292: bump ansible-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible==6.2.0
+ansible-core>=2.12.10
 ansible-lint>=5.1.2,<6.0.0
 docker>=4.3.1
 pytest-testinfra>=6.3.0


### PR DESCRIPTION
Откатываю изменения на последний релизный и надо явно поднять версию ansible-core т к тесты падают https://github.com/uchiru/role-bootstrap/actions/runs/5644444551/job/15288251907#step:4:258
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#parameter-allow_downgrade